### PR TITLE
Set unreachable to unloaded functions in release mode

### DIFF
--- a/src/Generator.cs
+++ b/src/Generator.cs
@@ -247,6 +247,7 @@ class Program
       stream.Write(cmd.GetSignature(true));
       stream.WriteLine(" {");
 
+      stream.WriteLine("    if (builtin.mode != .Debug and function_pointers.{0} == null) unreachable;", cmd.Prototype.Name);
       stream.Write("    return (function_pointers.{0} orelse @panic(\"{0} was not bound.\"))(", cmd.Prototype.Name);
       if (cmd.Parameters != null)
       {


### PR DESCRIPTION
I was looking my program output assembly code in release mode and I realized isn't removing a check about if an opengl function is loaded or not and I don't think it's a good idea checking this stuff in releases. 

So i added an if unreachable that makes zig remove the orelse check only if isn't in debug mode.