### PR TITLE
Update @ptrCast uses to infer result type

### DIFF
--- a/src/Generator.cs
+++ b/src/Generator.cs
@@ -273,7 +273,7 @@ class Program
     foreach (var cmd in commands)
     {
       stream.WriteLine("    if(get_proc_address(load_ctx, \"{0}\")) |proc| {{", cmd.Prototype.Name);
-      stream.WriteLine("        function_pointers.{0} = @ptrCast(@TypeOf(function_pointers.{0}),  proc);", cmd.Prototype.Name);
+      stream.WriteLine("        function_pointers.{0} = @ptrCast(proc);", cmd.Prototype.Name);
       stream.WriteLine("    } else {");
       stream.WriteLine("        log.err(\"entry point {0} not found!\", .{{}});", cmd.Prototype.Name);
       stream.WriteLine("        success = false;");


### PR DESCRIPTION
This fixes the `@ptrCast` uses in the bindings generator to work with zig 0.11 as per the changes of https://github.com/ziglang/zig/pull/16163 