### PR TITLE
NET 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           version: master
 
-      - name: Install dotnet 6.0
+      - name: Install dotnet 7.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x' # SDK Version to use; x will use the latest version of the 3.1 channel
+          dotnet-version: '7.0.x' # SDK Version to use; x will use the latest version of the 3.1 channel
 
       - name: Build the generator
         run: dotnet build

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ EXTENSIONS?=
 
 NOTEST?=n
 
-EXE=bin/Debug/net6.0/generator
+EXE=bin/Debug/net7.0/generator
 GENERATOR?=$(EXE)
 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This function will load all OpenGL entry points with the help of `get_proc_addre
 
 **NOTE:** Please do not reference `zig-opengl` as a submodule or a package. Generate a binding and copy the output of that into your repository and update the file on demand. The OpenGL Registry is just too huge to be used conveniently.
 
+Cloning submodules is required, so use `--recursive`:
+
+```bash
+git clone --recursive https://github.com/MasterQ32/zig-opengl.git
+```
+
 ## Example
 
 This example uses [ZWL](https://github.com/Aransentin/ZWL/) by @Aransentin.

--- a/generator.csproj
+++ b/generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
Hi Felix,

Thanks for providing this tool.

If I use a vanilla Homebrew install `brew install dotnet` on macOS Sonoma, it was complaining that it couldn't find version 6.0. I know nothing about C# or .NET, but bumping the number in a config worked and generated the file. So I thought it might make life easier for the next person if it's updated.

To resolve:

```
Framework: 'Microsoft.NETCore.App', version '6.0.0' (arm64)
.NET location: /opt/homebrew/Cellar/dotnet/7.0.100/libexec

The following frameworks were found:
  7.0.0 at [/opt/homebrew/Cellar/dotnet/7.0.100/libexec/shared/Microsoft.NETCore.App]
```

Also added a mention of submodules and --recursive to the readme. Thanks again!